### PR TITLE
no_std support, bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,46 +3,10 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "anyhow"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
-
-[[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base16"
@@ -52,13 +16,11 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "blake2"
-version = "0.9.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "crypto-mac",
- "digest",
- "opaque-debug",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -66,6 +28,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -83,12 +54,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
-name = "cc"
-version = "1.0.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,22 +69,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "debug-cell"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ee4fc02f25a0400fb57135bcdde6d58a3025718749375f2f97abc3deb3a4ef"
-dependencies = [
- "backtrace",
+ "typenum",
 ]
 
 [[package]]
@@ -129,6 +85,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -143,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -153,41 +120,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
-
-[[package]]
 name = "libc"
 version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
-
-[[package]]
-name = "memchr"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -197,9 +133,30 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -234,18 +191,12 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
 dependencies = [
  "rand_core",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "scorex_crypto_avltree"
@@ -256,7 +207,6 @@ dependencies = [
  "blake2",
  "byteorder",
  "bytes",
- "debug-cell",
  "rand",
  "sha2",
 ]
@@ -267,10 +217,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -281,10 +231,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
-name = "typenum"
-version = "1.13.0"
+name = "syn"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "version_check"
@@ -297,3 +264,24 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "scorex_crypto_avltree"
 version = "0.1.0"
 authors = ["Konstantin Knizhnik <knizhnik@garret.ru>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Implementation of cryptographically authenticated dictionary based on AVL tree"
 documentation = "https://eprint.iacr.org/2016/994"
@@ -12,11 +12,13 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = { version = "1.0.1" }
-rand = "0.8.3"
-blake2 = "0.9"
-anyhow = "1.0"
-byteorder = "1.4.3"
-base16 = "0.2.1"
-debug-cell = "0.1.1"
-sha2 = "0.9.8"
+bytes = { version = "1.0.1", default-features = false }
+rand = { version = "0.8.3", default-features = false }
+blake2 = { version = "0.10.6", default-features = false }
+anyhow = { version = "1.0", default-features = false }
+byteorder = { version = "1.4.3", default-features = false }
+base16 = { version = "0.2.1", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.9.8", default-features = false }
+
+[dev-dependencies]
+rand = { version = "0.8.3", features = ["std"] }

--- a/src/authenticated_tree_ops.rs
+++ b/src/authenticated_tree_ops.rs
@@ -1,5 +1,6 @@
 use crate::batch_node::*;
 use crate::operation::*;
+use alloc::vec::Vec;
 use bytes::{BufMut, BytesMut};
 
 use anyhow::*;

--- a/src/batch_avl_prover.rs
+++ b/src/batch_avl_prover.rs
@@ -1,11 +1,13 @@
 use crate::authenticated_tree_ops::*;
 use crate::batch_node::*;
 use crate::operation::*;
+use alloc::vec;
+use alloc::vec::Vec;
 use anyhow::Result;
 use bytes::{BufMut, Bytes, BytesMut};
+use core::cmp::Ordering;
 use rand::prelude::*;
 use rand::RngCore;
-use std::cmp::Ordering;
 
 ///
 /// Implements the batch AVL prover from https://eprint.iacr.org/2016/994
@@ -335,7 +337,7 @@ impl BatchAVLProver {
                         && r.balance <= 1
                         && r.balance == (right_height as i8 - left_height as i8)
                 );
-                let height = std::cmp::max(left_height, right_height) + 1;
+                let height = core::cmp::max(left_height, right_height) + 1;
                 (min_left, max_right, height)
             }
             _ => (r_node.clone(), r_node.clone(), 1),

--- a/src/batch_avl_verifier.rs
+++ b/src/batch_avl_verifier.rs
@@ -1,6 +1,7 @@
 use crate::authenticated_tree_ops::*;
 use crate::batch_node::*;
 use crate::operation::*;
+use alloc::vec::Vec;
 use anyhow::*;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
@@ -73,7 +74,7 @@ impl BatchAVLVerifier {
             }
 
             // compute maximum height that the tree can be before an operation
-            temp = 1 + std::cmp::max(self.base.tree.height, log_num_ops);
+            temp = 1 + core::cmp::max(self.base.tree.height, log_num_ops);
             let hnew = temp + temp / 2; // this will replace 1.4405 from the paper with 1.5 and will round down, which is safe, because hnew is an integer
             let real_max_deletes = self.max_deletes.unwrap_or(real_num_operations);
             // Note: this is quite likely a lot more than there will really be nodes
@@ -155,13 +156,19 @@ impl BatchAVLVerifier {
     ///
     pub fn perform_one_operation(&mut self, operation: &Operation) -> Result<Option<ADValue>> {
         self.replay_index = self.directions_index;
-		let root = self.base.tree.root.as_ref().ok_or(anyhow!("Empty tree"))?.clone();
-		let res = self.return_result_of_one_operation(operation, &root);
-		if res.is_err() {
-			self.base.tree.root = None;
-			self.base.tree.height = 0;
-		}
-		res
+        let root = self
+            .base
+            .tree
+            .root
+            .as_ref()
+            .ok_or(anyhow!("Empty tree"))?
+            .clone();
+        let res = self.return_result_of_one_operation(operation, &root);
+        if res.is_err() {
+            self.base.tree.root = None;
+            self.base.tree.height = 0;
+        }
+        res
     }
 }
 
@@ -209,7 +216,7 @@ impl AuthenticatedTreeOps for BatchAVLVerifier {
         // checks that the key is either equal to the leaf's key
         // or is between the leaf's key and its nextLeafKey
         // See https://eprint.iacr.org/2016/994 Appendix B paragraph "Our Algorithms"
-		let leaf_key = leaf.hdr.key.as_ref().unwrap();
+        let leaf_key = leaf.hdr.key.as_ref().unwrap();
         if *key == *leaf_key {
             Ok(true)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 pub mod authenticated_tree_ops;
 pub mod batch_avl_prover;
 pub mod batch_avl_verifier;
@@ -5,3 +6,6 @@ pub mod batch_node;
 pub mod operation;
 pub mod persistent_batch_avl_prover;
 pub mod versioned_avl_storage;
+
+#[macro_use]
+extern crate alloc;

--- a/src/persistent_batch_avl_prover.rs
+++ b/src/persistent_batch_avl_prover.rs
@@ -3,6 +3,8 @@ use crate::batch_avl_prover::*;
 use crate::batch_node::*;
 use crate::operation::*;
 use crate::versioned_avl_storage::*;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use anyhow::{ensure, Result};
 
 pub struct PersistentBatchAVLProver {

--- a/src/versioned_avl_storage.rs
+++ b/src/versioned_avl_storage.rs
@@ -1,8 +1,10 @@
 use crate::batch_avl_prover::*;
 use crate::batch_node::*;
 use crate::operation::*;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use anyhow::Result;
-use std::iter::Iterator;
+use core::iter::Iterator;
 
 ///
 /// Interface for persistent versioned


### PR DESCRIPTION
Needed for sigma-rust no_std support. Can a new version be published on crates.io when this is merged?